### PR TITLE
Add tenant activation guard to registration

### DIFF
--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -21,6 +21,11 @@ def register_user(payload: auth_schemas.UserRegister, db: Session = Depends(get_
     tenant = db.query(models.Tenant).filter(models.Tenant.slug == payload.tenant_slug).first()
     if not tenant:
         raise HTTPException(status_code=404, detail="Tenant inválido")
+    if not tenant.ativo:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Tenant inativo: não é possível registar utilizadores",
+        )
 
     existing = db.query(models.User).filter(models.User.email == payload.email).first()
     if existing:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,34 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
 import pytest
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from app.infrastructure.db.base_class import Base
 from app.infrastructure.db import models
 from app.domain.enums import UserRole
+from app.core.deps import get_db
+from app.main import app
 
 
 @pytest.fixture()
 def db_session() -> Session:
     """Cria uma sessão SQLite em memória para testes unitários."""
-    engine = create_engine("sqlite:///:memory:", future=True)
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
     TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     Base.metadata.create_all(engine)
     session = TestingSessionLocal()
@@ -93,3 +111,19 @@ def db_session() -> Session:
     finally:
         session.close()
         Base.metadata.drop_all(engine)
+
+
+@pytest.fixture()
+def client(db_session: Session) -> TestClient:
+    """Instancia um TestClient com a sessão de BD de testes."""
+
+    def _get_test_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _get_test_db
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.pop(get_db, None)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,27 @@
+"""Testes do módulo de autenticação."""
+
+from __future__ import annotations
+
+from app.infrastructure.db import models
+
+
+def test_recusa_registo_para_tenant_inativo(client, db_session):
+    """Garante que o endpoint /register devolve 403 quando o tenant está inativo."""
+
+    tenant_inativo = models.Tenant(nome="Tenant Inativo", slug="tenant-inativo", ativo=False)
+    db_session.add(tenant_inativo)
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/auth/register",
+        json={
+            "email": "novo.cliente@example.com",
+            "password": "SenhaForte123",
+            "nome": "Cliente Novo",
+            "telefone": "910000001",
+            "tenant_slug": tenant_inativo.slug,
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Tenant inativo: não é possível registar utilizadores"


### PR DESCRIPTION
## Summary
- block user registration when a tenant is inactive and return a clear 403 error
- expose a FastAPI TestClient fixture for API tests and cover the inactive-tenant registration case

## Testing
- pytest tests/test_auth.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170f6a64ec8324bb5034144f7577c7)