### PR TITLE
Filter merchant dashboard metrics by paid orders

### DIFF
--- a/app/schemas/dashboard.py
+++ b/app/schemas/dashboard.py
@@ -1,0 +1,44 @@
+"""Esquemas Pydantic para respostas do dashboard."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class MerchantTopProduto(BaseModel):
+    """Produto mais vendido por merchant."""
+
+    produto_id: UUID
+    nome: str
+    total_vendido: int
+
+
+class MerchantPedidoRecente(BaseModel):
+    """Pedido recente retornado no dashboard."""
+
+    pedido_id: UUID
+    total: float
+    data: datetime
+    status: str
+
+
+class MerchantSummary(BaseModel):
+    """Resumo consolidado de métricas do merchant autenticado."""
+
+    merchant_id: UUID
+    total_pedidos: int
+    faturacao_total: float
+    total_pedidos_por_status: Dict[str, int]
+    top_produtos: List[MerchantTopProduto]
+    ultimos_pedidos: List[MerchantPedidoRecente]
+
+
+__all__ = [
+    "MerchantSummary",
+    "MerchantTopProduto",
+    "MerchantPedidoRecente",
+]

--- a/docs/API_CALLS.md
+++ b/docs/API_CALLS.md
@@ -42,6 +42,28 @@ curl -X POST http://localhost:8000/api/v1/agendamentos \
 curl http://localhost:8000/api/v1/dashboard/merchant/me/resumo \
   -H "Authorization: Bearer {{MERCHANT_TOKEN}}" \
   -H "X-Tenant-ID: {{TENANT_UUID}}"
+
+# Resposta esperada (exemplo)
+{
+  "merchant_id": "<UUID_MERCHANT>",
+  "total_pedidos": 12,
+  "faturacao_total": 845.5,
+  "total_pedidos_por_status": {
+    "PAGO": 12,
+    "CANCELADO": 1
+  },
+  "top_produtos": [
+    {"produto_id": "<UUID_PRODUTO>", "nome": "Produto X", "total_vendido": 24}
+  ],
+  "ultimos_pedidos": [
+    {
+      "pedido_id": "<UUID_PEDIDO>",
+      "total": 42.5,
+      "data": "2024-07-01T10:00:00+00:00",
+      "status": "PAGO"
+    }
+  ]
+}
 ```
 
 > Use Swagger UI (`/docs`) para experimentar e gerar exemplos de payload dinamicamente.

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,103 @@
+"""Testes para o resumo do dashboard do merchant."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.api.v1.routes.dashboard import merchant_summary
+from app.core.deps import TenantContext
+from app.domain.enums import PedidoStatus
+from app.infrastructure.db import models
+
+
+@pytest.fixture()
+def merchant_context(db_session):
+    tenant = db_session.query(models.Tenant).first()
+    merchant = db_session.query(models.Merchant).first()
+    assert tenant is not None
+    assert merchant is not None
+    return TenantContext(id=tenant.id, slug=tenant.slug, is_active=tenant.ativo), merchant
+
+
+def _criar_pedido(
+    db_session,
+    *,
+    tenant,
+    cliente,
+    produto,
+    status: PedidoStatus,
+    quantidade: int,
+):
+    unitario = Decimal(str(produto.preco))
+    total = unitario * quantidade
+    pedido = models.Pedido(
+        cliente_id=cliente.id,
+        tenant_id=tenant.id,
+        subtotal=total,
+        total=total,
+        status=status,
+    )
+    db_session.add(pedido)
+    db_session.flush()
+
+    item = models.ItemPedido(
+        pedido_id=pedido.id,
+        tipo="produto",
+        ref_id=produto.id,
+        quantidade=quantidade,
+        preco_unitario=unitario,
+        tenant_id=tenant.id,
+    )
+    db_session.add(item)
+    db_session.flush()
+    return pedido
+
+
+def test_merchant_summary_considera_apenas_pedidos_pagos(db_session, merchant_context):
+    tenant_context, merchant = merchant_context
+    tenant = db_session.query(models.Tenant).first()
+    cliente = db_session.query(models.Cliente).first()
+    produto = db_session.query(models.Produto).first()
+
+    assert tenant is not None
+    assert cliente is not None
+    assert produto is not None
+
+    _criar_pedido(
+        db_session,
+        tenant=tenant,
+        cliente=cliente,
+        produto=produto,
+        status=PedidoStatus.PAGO,
+        quantidade=2,
+    )
+    _criar_pedido(
+        db_session,
+        tenant=tenant,
+        cliente=cliente,
+        produto=produto,
+        status=PedidoStatus.PAGO,
+        quantidade=1,
+    )
+    _criar_pedido(
+        db_session,
+        tenant=tenant,
+        cliente=cliente,
+        produto=produto,
+        status=PedidoStatus.CANCELADO,
+        quantidade=5,
+    )
+    db_session.commit()
+
+    resultado = merchant_summary(db=db_session, tenant=tenant_context, merchant=merchant)
+
+    assert resultado["total_pedidos"] == 2
+    assert resultado["faturacao_total"] == pytest.approx(75.0)
+    assert resultado["total_pedidos_por_status"][PedidoStatus.PAGO.value] == 2
+    assert resultado["total_pedidos_por_status"][PedidoStatus.CANCELADO.value] == 1
+    assert resultado["top_produtos"][0]["total_vendido"] == 3
+    statuses = {pedido["status"] for pedido in resultado["ultimos_pedidos"]}
+    assert PedidoStatus.PAGO.value in statuses
+    assert PedidoStatus.CANCELADO.value in statuses


### PR DESCRIPTION
## Summary
- filter the merchant dashboard aggregates to include only paid pedidos and expose per-status counts
- add a dedicated Pydantic response schema for the merchant summary and document the new payload fields
- backfill automated coverage for the paid-status filtering logic on the dashboard endpoint

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171102ffcc83248649da929b9a1ef8)