### PR TITLE
Update API calls documentation with current endpoints

### DIFF
--- a/docs/API_CALLS.md
+++ b/docs/API_CALLS.md
@@ -1,29 +1,111 @@
 # Exemplos de Chamadas HTTP
 
-Substituir `{{TOKEN}}`, `{{TENANT_UUID}}` e `{{TENANT_SLUG}}` pelos valores reais.
+Os exemplos abaixo assumem que a API está disponível em `http://localhost:8000` e que o Swagger UI pode ser consultado em `http://localhost:8000/docs` para explorar schemas completos.
+
+## Convenções Gerais
+
+- Substitua `{{TOKEN}}`, `{{SUPERADMIN_TOKEN}}`, `{{MERCHANT_TOKEN}}` e `{{PRESTADOR_TOKEN}}` por JWTs válidos obtidos através do endpoint de login.
+- O cabeçalho multi-tenant definido em `settings.tenant_header` é `X-Tenant-ID`. Aceita *slug* ou UUID do tenant ativo.
+- Todos os exemplos usam `curl`; ajuste conforme necessário para outras ferramentas (HTTPie, Postman, etc.).
 
 ```bash
-# 1. Criar tenant (SUPERADMIN)
-curl -X POST http://localhost:8000/api/v1/tenants \
+BASE_URL="http://localhost:8000/api/v1"
+TENANT_SLUG="lisboa"
+TENANT_ID="00000000-0000-0000-0000-000000000001" # opcional: pode ser o mesmo slug
+```
+
+---
+
+## Tenants (SUPERADMIN)
+
+```bash
+# Criar tenant
+curl -X POST "$BASE_URL/tenants" \
   -H "Authorization: Bearer {{SUPERADMIN_TOKEN}}" \
   -H "Content-Type: application/json" \
   -d '{"nome":"Lisboa Hub","slug":"lisboa","ativo":true}'
 
-# 2. Registar cliente
-curl -X POST http://localhost:8000/api/v1/auth/register \
+# Listar tenants
+curl "$BASE_URL/tenants" \
+  -H "Authorization: Bearer {{SUPERADMIN_TOKEN}}"
+
+# Obter tenant específico
+curl "$BASE_URL/tenants/${TENANT_ID}" \
+  -H "Authorization: Bearer {{SUPERADMIN_TOKEN}}"
+
+# Atualização parcial (nome ou estado)
+curl -X PATCH "$BASE_URL/tenants/${TENANT_ID}" \
+  -H "Authorization: Bearer {{SUPERADMIN_TOKEN}}" \
+  -H "Content-Type: application/json" \
+  -d '{"nome":"Lisboa Hub Central","ativo":false}'
+```
+
+Exemplo de resposta (`GET /tenants`):
+
+```json
+[
+  {
+    "id": "<UUID>",
+    "nome": "Lisboa Hub",
+    "slug": "lisboa",
+    "ativo": true
+  }
+]
+```
+
+---
+
+## Autenticação e Utilizadores
+
+```bash
+# Registar cliente associado a um tenant ativo
+curl -X POST "$BASE_URL/auth/register" \
   -H "Content-Type: application/json" \
   -d '{"email":"cliente@acme.com","password":"Teste123","nome":"Cliente","telefone":"+351910000000","tenant_slug":"lisboa"}'
 
-# 3. Login (recebe JWT)
-curl -X POST http://localhost:8000/api/v1/auth/login \
+# Login (retorna JWT)
+curl -X POST "$BASE_URL/auth/login" \
   -H "Content-Type: application/json" \
   -d '{"email":"cliente@acme.com","password":"Teste123"}'
 
-# 4. Listar merchants do tenant (via slug ou UUID)
-curl "http://localhost:8000/api/v1/merchants?destaque=true&page=1&page_size=20" \
-  -H "X-Tenant-ID: lisboa"
+# Perfil do utilizador autenticado
+curl "$BASE_URL/auth/me" \
+  -H "Authorization: Bearer {{TOKEN}}"
+```
 
-# Resposta (paginação com metadata)
+Resposta de `GET /auth/me` (exemplo):
+
+```json
+{
+  "id": "<UUID>",
+  "email": "cliente@acme.com",
+  "role": "CLIENTE",
+  "tenant_id": "<UUID_TENANT>"
+}
+```
+
+---
+
+## Catálogo de Merchants e Produtos
+
+```bash
+# Listar merchants com filtros opcionais
+curl "$BASE_URL/merchants?destaque=true&tipo=produtos&search=loja&page=1&page_size=20" \
+  -H "X-Tenant-ID: ${TENANT_SLUG}"
+
+# Obter merchant por slug ou UUID
+curl "$BASE_URL/merchants/loja-do-centro" \
+  -H "X-Tenant-ID: ${TENANT_SLUG}"
+
+# Listar produtos de um merchant específico
+MERCHANT_ID="11111111-1111-1111-1111-111111111111"
+curl "$BASE_URL/merchants/${MERCHANT_ID}/produtos" \
+  -H "X-Tenant-ID: ${TENANT_SLUG}"
+```
+
+Resposta paginada de `GET /merchants`:
+
+```json
 {
   "items": [
     {
@@ -40,28 +122,106 @@ curl "http://localhost:8000/api/v1/merchants?destaque=true&page=1&page_size=20" 
   "page_size": 20,
   "total_pages": 1
 }
+```
 
-# 5. Checkout
-token=$(...) # token cliente
-curl -X POST http://localhost:8000/api/v1/checkout \
-  -H "Authorization: Bearer ${token}" \
-  -H "X-Tenant-ID: {{TENANT_UUID}}" \
+Exemplo de resposta de `GET /merchants/{merchant_id}/produtos`:
+
+```json
+[
+  {
+    "id": "<UUID_PRODUTO>",
+    "nome": "Produto X",
+    "preco": 25.5,
+    "disponivel": true
+  }
+]
+```
+
+---
+
+## Checkout (Cliente autenticado)
+
+```bash
+TOKEN_CLIENTE="{{TOKEN}}"
+
+curl -X POST "$BASE_URL/checkout" \
+  -H "Authorization: Bearer ${TOKEN_CLIENTE}" \
+  -H "X-Tenant-ID: ${TENANT_ID}" \
   -H "Content-Type: application/json" \
   -d '{"itens":[{"tipo":"produto","ref_id":"<UUID_DO_PRODUTO>","quantidade":2}]}'
+```
 
-# 6. Criar agendamento
-curl -X POST http://localhost:8000/api/v1/agendamentos \
-  -H "Authorization: Bearer ${token}" \
-  -H "X-Tenant-ID: {{TENANT_UUID}}" \
+Resposta (exemplo):
+
+```json
+{
+  "id": "<UUID_PEDIDO>",
+  "subtotal": 51.0,
+  "total": 51.0,
+  "status": "PENDENTE",
+  "itens": [
+    {
+      "id": "<UUID_ITEM>",
+      "tipo": "produto",
+      "ref_id": "<UUID_DO_PRODUTO>",
+      "quantidade": 2,
+      "preco_unitario": 25.5
+    }
+  ]
+}
+```
+
+---
+
+## Agendamentos (Cliente autenticado)
+
+```bash
+curl -X POST "$BASE_URL/agendamentos" \
+  -H "Authorization: Bearer ${TOKEN_CLIENTE}" \
+  -H "X-Tenant-ID: ${TENANT_ID}" \
   -H "Content-Type: application/json" \
-  -d '{"prestador_id":"<UUID_PRESTADOR>","servico_id":"<UUID_SERVICO>","data_hora":"2024-07-01T10:00:00Z","nome":"Cliente","contacto":"+351910000000"}'
+  -d '{
+        "prestador_id":"<UUID_PRESTADOR>",
+        "servico_id":"<UUID_SERVICO>",
+        "data_hora":"2024-07-01T10:00:00Z",
+        "nome":"Cliente",
+        "contacto":"+351910000000",
+        "observacoes":"Trazer documentação"
+      }'
+```
 
-# 7. Dashboard Merchant
-curl http://localhost:8000/api/v1/dashboard/merchant/me/resumo \
+Resposta (exemplo):
+
+```json
+{
+  "id": "<UUID_AGENDAMENTO>",
+  "prestador_id": "<UUID_PRESTADOR>",
+  "servico_id": "<UUID_SERVICO>",
+  "data_hora": "2024-07-01T10:00:00+00:00",
+  "status": "PENDENTE",
+  "metadados_formulario": {}
+}
+```
+
+---
+
+## Dashboards
+
+```bash
+# Resumo do merchant autenticado
+curl "$BASE_URL/dashboard/merchant/me/resumo" \
   -H "Authorization: Bearer {{MERCHANT_TOKEN}}" \
-  -H "X-Tenant-ID: {{TENANT_UUID}}"
+  -H "X-Tenant-ID: ${TENANT_ID}"
 
-# Resposta esperada (exemplo)
+# Resumo do prestador autenticado
+curl "$BASE_URL/dashboard/prestador/me/resumo" \
+  -H "Authorization: Bearer {{PRESTADOR_TOKEN}}" \
+  -H "X-Tenant-ID: ${TENANT_ID}"
+```
+
+Resposta de `GET /dashboard/merchant/me/resumo` (exemplo):
+
+```json
 {
   "merchant_id": "<UUID_MERCHANT>",
   "total_pedidos": 12,
@@ -84,4 +244,25 @@ curl http://localhost:8000/api/v1/dashboard/merchant/me/resumo \
 }
 ```
 
-> Use Swagger UI (`/docs`) para experimentar e gerar exemplos de payload dinamicamente.
+Resposta de `GET /dashboard/prestador/me/resumo` (exemplo):
+
+```json
+{
+  "prestador_id": "<UUID_PRESTADOR>",
+  "total_por_status": {
+    "PENDENTE": 3,
+    "CONFIRMADO": 5
+  },
+  "proximos_agendamentos": [
+    {
+      "agendamento_id": "<UUID_AGENDAMENTO>",
+      "cliente_id": "<UUID_CLIENTE>",
+      "servico_id": "<UUID_SERVICO>",
+      "data_hora": "2024-07-05T09:30:00+00:00",
+      "status": "CONFIRMADO"
+    }
+  ]
+}
+```
+
+> Utilize o Swagger UI (`/docs`) para gerar exemplos adicionais e testar parâmetros dinamicamente.


### PR DESCRIPTION
## Summary
- refresh docs/API_CALLS.md to cover current tenant, auth, catalogue, checkout, agendamento and dashboard endpoints
- document required headers, sample payloads and responses for the updated FastAPI routes

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917197dba0c8324992c0660e598af6f)