### PR TITLE
Refactor tenant management into dedicated service

### DIFF
--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -9,6 +9,7 @@ from app.core.deps import get_db, get_current_user
 from app.core.security import create_access_token, get_password_hash, verify_password
 from app.domain.enums import UserRole
 from app.infrastructure.db import models
+from app.services import tenant_service
 from app.schemas import auth as auth_schemas
 
 router = APIRouter()
@@ -18,7 +19,7 @@ router = APIRouter()
 def register_user(payload: auth_schemas.UserRegister, db: Session = Depends(get_db)):
     """Regista um novo cliente associado a um tenant existente."""
 
-    tenant = db.query(models.Tenant).filter(models.Tenant.slug == payload.tenant_slug).first()
+    tenant = tenant_service.get_tenant_by_slug(db, payload.tenant_slug)
     if not tenant:
         raise HTTPException(status_code=404, detail="Tenant inválido")
     if not tenant.ativo:

--- a/app/core/deps.py
+++ b/app/core/deps.py
@@ -15,6 +15,7 @@ from app.core.config import settings
 from app.core.security import decode_token
 from app.domain.enums import UserRole
 from app.infrastructure.db import models
+from app.services import tenant_service
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
 
@@ -42,12 +43,7 @@ def get_tenant(request: Request, db: Session = Depends(get_db)) -> TenantContext
     if not tenant_identifier:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Tenant não informado")
 
-    tenant = None
-    try:
-        tenant_uuid = UUID(tenant_identifier)
-        tenant = db.query(models.Tenant).filter(models.Tenant.id == tenant_uuid).first()
-    except ValueError:
-        tenant = db.query(models.Tenant).filter(models.Tenant.slug == tenant_identifier).first()
+    tenant = tenant_service.get_tenant_by_identifier(db, tenant_identifier)
 
     if not tenant or not tenant.ativo:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant inválido/inativo")

--- a/app/services/tenant_service.py
+++ b/app/services/tenant_service.py
@@ -1,0 +1,68 @@
+"""Serviços auxiliares para gerir tenants."""
+
+from __future__ import annotations
+
+from typing import Iterable
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.infrastructure.db import models
+
+
+def get_tenant_by_slug(db: Session, slug: str) -> models.Tenant | None:
+    """Obtém um tenant a partir do slug único."""
+
+    return db.query(models.Tenant).filter(models.Tenant.slug == slug).first()
+
+
+def get_tenant_by_id(db: Session, tenant_id: UUID) -> models.Tenant | None:
+    """Carrega um tenant pelo identificador UUID."""
+
+    return db.get(models.Tenant, tenant_id)
+
+
+def get_tenant_by_identifier(db: Session, identifier: str) -> models.Tenant | None:
+    """Aceita slug ou UUID para resolver o tenant correspondente."""
+
+    try:
+        tenant_uuid = UUID(identifier)
+    except ValueError:
+        return get_tenant_by_slug(db, identifier)
+    return get_tenant_by_id(db, tenant_uuid)
+
+
+def list_tenants(db: Session) -> Iterable[models.Tenant]:
+    """Lista todos os tenants ordenados pelo nome."""
+
+    return db.query(models.Tenant).order_by(models.Tenant.nome.asc()).all()
+
+
+def create_tenant(db: Session, *, nome: str, slug: str, ativo: bool) -> models.Tenant:
+    """Cria e persiste um tenant."""
+
+    tenant = models.Tenant(nome=nome, slug=slug, ativo=ativo)
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+def update_tenant(
+    db: Session,
+    tenant: models.Tenant,
+    *,
+    nome: str | None = None,
+    ativo: bool | None = None,
+) -> models.Tenant:
+    """Atualiza campos mutáveis do tenant."""
+
+    if nome is not None:
+        tenant.nome = nome
+    if ativo is not None:
+        tenant.ativo = ativo
+
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant

--- a/tests/test_tenant_service.py
+++ b/tests/test_tenant_service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from app.services import tenant_service
+from app.infrastructure.db import models
+
+
+def test_get_tenant_by_identifier_accepts_slug(db_session):
+    tenant = tenant_service.get_tenant_by_identifier(db_session, "tenant-teste")
+    assert tenant is not None
+    assert tenant.slug == "tenant-teste"
+
+
+def test_get_tenant_by_identifier_accepts_uuid(db_session):
+    existing = db_session.query(models.Tenant).first()
+    tenant = tenant_service.get_tenant_by_identifier(db_session, str(existing.id))
+    assert tenant is not None
+    assert tenant.id == existing.id
+
+
+def test_create_and_update_tenant(db_session):
+    novo = tenant_service.create_tenant(
+        db_session,
+        nome="Tenant Novo",
+        slug="tenant-novo",
+        ativo=True,
+    )
+    assert tenant_service.get_tenant_by_slug(db_session, "tenant-novo").id == novo.id
+
+    atualizado = tenant_service.update_tenant(db_session, novo, nome="Tenant Atualizado", ativo=False)
+    assert atualizado.nome == "Tenant Atualizado"
+    assert atualizado.ativo is False


### PR DESCRIPTION
## Summary
- extract reusable helpers for tenant lookup and persistence into a dedicated service module
- refactor tenant-aware dependencies and authentication endpoints to use the centralized tenant service
- add unit tests covering tenant resolution, creation, and updates

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178f708f5c83249bb12ff97854756c)