### PR TITLE
Implement Category CRUD per Merchant with multi-tenant isolation (Cloes #3)

### DIFF
--- a/app/api/v1/routes/merchants.py
+++ b/app/api/v1/routes/merchants.py
@@ -8,9 +8,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from app.core.deps import TenantContext, get_db, get_tenant
+from app.core.deps import TenantContext, get_current_active_tenant, get_current_user, get_db, get_tenant
 from app.infrastructure.db import models
 from app.schemas import merchant as merchant_schemas
+from app.schemas.merchant import CategoriaCreate, CategoriaListResponse, CategoriaOut, CategoriaUpdate
+from app.domain.enums import UserRole
+from fastapi import status
 
 router = APIRouter()
 
@@ -84,3 +87,160 @@ def list_produtos(
         .all()
     )
     return produtos
+
+
+# Categorias CRUD para merchants autenticados
+
+
+def _get_merchant_for_user(
+    *, merchant_id: UUID, tenant: TenantContext, db: Session, user: models.User
+) -> models.Merchant:
+    merchant = (
+        db.query(models.Merchant)
+        .filter(models.Merchant.tenant_id == tenant.id, models.Merchant.id == merchant_id)
+        .first()
+    )
+    if not merchant:
+        raise HTTPException(status_code=404, detail="Merchant não encontrado")
+    if user.role == UserRole.MERCHANT and merchant.owner_id != user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este merchant")
+    return merchant
+
+
+@router.post(
+    "/{merchant_id}/categorias",
+    response_model=CategoriaOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_categoria(
+    merchant_id: UUID,
+    payload: CategoriaCreate,
+    tenant: TenantContext = Depends(get_current_active_tenant),
+    user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    merchant = _get_merchant_for_user(merchant_id=merchant_id, tenant=tenant, db=db, user=user)
+    categoria = models.Categoria(
+        tenant_id=tenant.id,
+        merchant_id=merchant.id,
+        nome=payload.nome,
+        slug=payload.slug,
+        descricao=payload.descricao,
+        ordem=payload.ordem,
+        ativa=payload.ativa,
+    )
+    db.add(categoria)
+    db.commit()
+    db.refresh(categoria)
+    return categoria
+
+
+@router.get("/{merchant_id}/categorias", response_model=CategoriaListResponse)
+def list_categorias_merchant(
+    merchant_id: UUID,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    ativa: bool | None = None,
+    tenant: TenantContext = Depends(get_current_active_tenant),
+    user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _get_merchant_for_user(merchant_id=merchant_id, tenant=tenant, db=db, user=user)
+    query = (
+        db.query(models.Categoria)
+        .filter(models.Categoria.tenant_id == tenant.id, models.Categoria.merchant_id == merchant_id)
+        .order_by(models.Categoria.ordem, models.Categoria.nome)
+    )
+    if ativa is not None:
+        query = query.filter(models.Categoria.ativa == ativa)
+    total = query.count()
+    offset = (page - 1) * page_size
+    categorias = query.offset(offset).limit(page_size).all()
+    total_pages = (total + page_size - 1) // page_size if page_size else 1
+    return CategoriaListResponse(
+        total=total,
+        items=categorias,
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages,
+    )
+
+
+@router.get("/{merchant_id}/categorias/{categoria_id}", response_model=CategoriaOut)
+def get_categoria(
+    merchant_id: UUID,
+    categoria_id: UUID,
+    tenant: TenantContext = Depends(get_current_active_tenant),
+    user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _get_merchant_for_user(merchant_id=merchant_id, tenant=tenant, db=db, user=user)
+    categoria = (
+        db.query(models.Categoria)
+        .filter(
+            models.Categoria.tenant_id == tenant.id,
+            models.Categoria.merchant_id == merchant_id,
+            models.Categoria.id == categoria_id,
+        )
+        .first()
+    )
+    if not categoria:
+        raise HTTPException(status_code=404, detail="Categoria não encontrada")
+    return categoria
+
+
+@router.patch("/{merchant_id}/categorias/{categoria_id}", response_model=CategoriaOut)
+def update_categoria(
+    merchant_id: UUID,
+    categoria_id: UUID,
+    payload: CategoriaUpdate,
+    tenant: TenantContext = Depends(get_current_active_tenant),
+    user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _get_merchant_for_user(merchant_id=merchant_id, tenant=tenant, db=db, user=user)
+    categoria = (
+        db.query(models.Categoria)
+        .filter(
+            models.Categoria.tenant_id == tenant.id,
+            models.Categoria.merchant_id == merchant_id,
+            models.Categoria.id == categoria_id,
+        )
+        .first()
+    )
+    if not categoria:
+        raise HTTPException(status_code=404, detail="Categoria não encontrada")
+
+    update_data = payload.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(categoria, key, value)
+    db.add(categoria)
+    db.commit()
+    db.refresh(categoria)
+    return categoria
+
+
+@router.delete("/{merchant_id}/categorias/{categoria_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_categoria(
+    merchant_id: UUID,
+    categoria_id: UUID,
+    tenant: TenantContext = Depends(get_current_active_tenant),
+    user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    _get_merchant_for_user(merchant_id=merchant_id, tenant=tenant, db=db, user=user)
+    categoria = (
+        db.query(models.Categoria)
+        .filter(
+            models.Categoria.tenant_id == tenant.id,
+            models.Categoria.merchant_id == merchant_id,
+            models.Categoria.id == categoria_id,
+        )
+        .first()
+    )
+    if not categoria:
+        raise HTTPException(status_code=404, detail="Categoria não encontrada")
+    categoria.ativa = False
+    db.add(categoria)
+    db.commit()
+    return None


### PR DESCRIPTION
Resumo do PR
Adicionei um router específico para o catálogo (app/api/v1/routes/catalog.py) que expõe listagens públicas paginadas de categorias e produtos, sempre filtradas por tenant_id.
Atualizei app/schemas/common.py e app/schemas/merchant.py para fornecer schemas completos (Create/Update/Out) para merchants, categorias, produtos, prestadores e serviços, além de envelopes PaginatedResponse[...].
Implementei o CRUD completo de categorias por merchant em app/api/v1/routes/merchants.py, com:
Endpoints POST/GET list/GET detail/PATCH/DELETE em /merchants/{merchant_id}/categorias.
Soft-delete via ativa = False.
Paginação e filtro ativa na listagem, ordenada por ordem/nome.
Validação de tenant e permissões (merchant só edita categorias do próprio ID no tenant).
Registei o novo router de catálogo no app/main.py.
Testes
Ambiente sem poetry; testes não corridos aqui. Após instalar dependências, correr poetry run pytest.