### PR TITLE
Add merchant-facing endpoints for viewing and managing orders (Closes #8)

### DIFF
--- a/app/domain/enums.py
+++ b/app/domain/enums.py
@@ -13,6 +13,10 @@ class PedidoStatus(str, Enum):
     PENDENTE_PAGAMENTO = "PENDENTE_PAGAMENTO"
     PAGO = "PAGO"
     CANCELADO = "CANCELADO"
+    ACEITE = "ACEITE"
+    EM_PREPARACAO = "EM_PREPARACAO"
+    ENVIADO = "ENVIADO"
+    CONCLUIDO = "CONCLUIDO"
 
 
 class AgendamentoStatus(str, Enum):

--- a/app/schemas/pedido.py
+++ b/app/schemas/pedido.py
@@ -1,0 +1,51 @@
+"""Schemas para pedidos na visão de merchants."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import List
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+from app.domain.enums import PedidoStatus
+
+
+class ItemPedidoResumo(BaseModel):
+    id: UUID
+    tipo: str
+    ref_id: UUID
+    nome_snapshot: str | None
+    quantidade: int
+    preco_unitario: Decimal
+    total_linha: Decimal
+    categoria_id_snapshot: UUID | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PedidoResumo(BaseModel):
+    id: UUID
+    subtotal: Decimal
+    total: Decimal
+    status: PedidoStatus
+    estado_pagamento: str | None
+    origem: str
+    created_at: datetime | None
+
+    cliente_nome_snapshot: str | None
+    cliente_email_snapshot: str | None
+    cliente_telefone_snapshot: str | None
+
+    itens: List[ItemPedidoResumo]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PedidoDetalhe(PedidoResumo):
+    endereco_entrega_snapshot: dict | None = None
+
+
+class PedidoStatusUpdate(BaseModel):
+    status: PedidoStatus


### PR DESCRIPTION
Implementei a visão de pedidos para merchants:

app/domain/enums.py ganhou os estados extra (ACEITE, EM_PREPARACAO, ENVIADO, CONCLUIDO) para suportar o workflow do merchant.
app/schemas/pedido.py define os DTOs PedidoResumo, PedidoDetalhe (com snapshots de cliente/endereço) e PedidoStatusUpdate.
app/api/v1/routes/merchants.py:
Importa os novos schemas/enums e expõe helpers (_get_owner_merchant, _pedido_para_schema, _get_pedido_para_merchant).
Adiciona GET /api/v1/merchants/me/pedidos (filtros por status, estado_pagamento e intervalos de criação/confirmação, com paginação simples), GET /api/v1/merchants/me/pedidos/{id} (mostra só itens do merchant + snapshots) e PATCH /api/v1/merchants/me/pedidos/{id}/status (transições limitadas às constantes MERCHANT_STATUS_ALLOWED).
Todos os endpoints validam o tenant e garantem que o utilizador é o owner do merchant.
Assim, o merchant consegue listar, consultar e atualizar os pedidos que incluem os seus produtos dentro do tenant, vendo apenas as linhas relevantes e os dados de contacto capturados no snapshot.